### PR TITLE
Fix: added editable install so pytest-cov finds notebook_service

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,13 +1,16 @@
+# .coveragerc
 [run]
-# Where your package lives
-source =
-    src/notebook_service
+# only measure code in your package
+source = notebook_service
 
-# Never measure coverage in your venv or tests
+# trace code in threads (TestClient spins up a thread)
+concurrency = thread
+
+[report]
+# show you exactly which lines were missed
+show_missing = True
+
+# don’t measure your venv or your tests
 omit =
     .venv/*
     tests/*
-
-[report]
-# Show missing lines in the terminal
-show_missing = True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,22 @@ jobs:
         with:
           python-version: "3.11"
 
-      # 3️⃣  Install deps (core + dev)
+      # 3️⃣  Cache pip downloads
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      # 4️⃣  Install deps (core + dev)
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          pip install ".[dev]"
+          pip install -e ".[dev]"
 
-      # 4️⃣  Restore cached pre-commit hook environments
+      # 5️⃣  Restore cached pre-commit hook environments
       - name: Restore pre-commit envs
         uses: actions/cache@v4
         with:
@@ -38,19 +47,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-precommit-
 
-      # 5️⃣  Lint & format checks (driven by .pre-commit-config.yaml)
+      # 6️⃣  Lint & format checks (driven by .pre-commit-config.yaml)
       - name: Lint and format (pre-commit)
         run: pre-commit run --all-files --hook-stage manual
 
-      # 6️⃣  Tests + coverage
+      # 7️⃣  Tests + coverage
       - name: Run tests with coverage
-        run: pytest --cov=src/notebook_service tests/
+        run: |
+          pytest \
+            --cov=notebook_service \
+            --cov-report=term-missing \
+            --cov-config=.coveragerc \
+            -q
 
-      # 7️⃣  Build Docker image (optional artifact)
+      # 8️⃣  Build Docker image (optional artifact)
       - name: Build Docker image
         run: docker build . --tag notebook-to-prod:ci
 
-      # 8️⃣  Test Docker image
+      # 9️⃣  Test Docker image
       - name: Run container & smoke-test
         run: |
           docker run -d --rm -p 8000:8000 \

--- a/README.md
+++ b/README.md
@@ -83,11 +83,8 @@ git add .
 git commit -m "Your meaningful commit message"
 # when ready to cut a release:
 git tag v1.1.0
+git describe --tags --exact-match
 git push origin main --tags
-# now:
-pip install .       # or build your package
-python -c "import pkg_resources; print(pkg_resources.get_distribution('notebook-to-prod-template').version)"
-# → prints '1.1.0'
 ```
 
 | Bump type | Version change example | What it signals                      |
@@ -121,8 +118,8 @@ Then in VS Code’s notebook kernel picker choose Python (notebook-to-prod)
 
 ```bash
 # 2) Install the project  ➜  core + dev extras (pytest, flake8, nbqa, …)
-py -m pip install --upgrade pip
-pip install ".[dev]"
+py -m pip install --upgrade pip setuptools
+pip install -e ".[dev]"
 pip-audit
 ```
 ```bash
@@ -160,5 +157,5 @@ docker exec -it <container_id> pytest
 
 Tip: If you need the docs inside Docker, expose the host and port:
 ```bash
-docker run -p 8000:8000 notebook-to-prod uvicorn notebook_service.main:app --host 0.0.0.0
+docker run -p 8000:8000 --env-file .env notebook-to-prod uvicorn notebook_service.main:app --host 0.0.0.0
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,8 @@ line-length = 79
 
 [tool.pytest.ini_options]
 addopts = [
-  "--cov",
-  "src/notebook_service",
-  "--cov-report",
-  "term-missing"
+  "--cov=notebook_service",
+  "--cov-report=term-missing"
 ]
 filterwarnings = [
   "ignore:.*Jupyter is migrating its paths.*:DeprecationWarning"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,8 @@
+[pytest]
+addopts =
+    --cov=notebook_service
+    --cov-report=term-missing
+    --cov-config=.coveragerc
+testpaths = tests
+filterwarnings =
+    ignore:.*Jupyter is migrating its paths.*:DeprecationWarning

--- a/src/notebook_service/main.py
+++ b/src/notebook_service/main.py
@@ -16,6 +16,7 @@ app = FastAPI(
 )
 
 
+# necessary to execise the API layer
 @app.get(
     "/run/{notebook_name}",
     response_model=NotebookOutputs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,26 +5,29 @@ import nbformat
 import pytest
 from fastapi.testclient import TestClient
 
-from notebook_service.main import app
-
 
 @pytest.fixture(autouse=True, scope="session")
 def use_selector_event_loop():
-    # On Windows, force the selector policy so ZMQ/Tornado is happy
     if hasattr(asyncio, "WindowsSelectorEventLoopPolicy"):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 
 @pytest.fixture(scope="session")
 def client():
+    # import inside the fixture so coverage can start first
+    from notebook_service.main import app
     return TestClient(app)
 
 
 @pytest.fixture
 def sample_notebook(tmp_path):
+    """
+    Create a minimal empty notebook file named <name>.ipynb in tmp_path.
+    Returns the pathlib.Path to that file.
+    """
     def _create(name="example"):
         nb = nbformat.v4.new_notebook()
-        (tmp_path / f"{name}.ipynb").write_text(nbformat.writes(nb))
-        return tmp_path / f"{name}.ipynb"
-
+        file = tmp_path / f"{name}.ipynb"
+        file.write_text(nbformat.writes(nb))
+        return file
     return _create


### PR DESCRIPTION
This PR ensures that our CI and local workflows install the `notebook_service` package in editable mode (`pip install -e .[dev]`), so pytest-cov measures the live `src/notebook_service` code instead of a stale copy in `site-packages`.

Closes #1
